### PR TITLE
Added option to hide the "Comments Closed" message when commenting is disabled

### DIFF
--- a/facebook-comments-admin.php
+++ b/facebook-comments-admin.php
@@ -388,6 +388,10 @@ if (version_compare(phpversion(), FBCOMMENTS_REQUIRED_PHP_VER) == -1) {
 			<p><input type="checkbox" id="fbComments_includeOpenGraphMeta" name="fbComments[includeOpenGraphMeta]" value="1" <?php checked($fbc_options['includeOpenGraphMeta'], 1 ); ?> size="20">
 				<label for="fbComments_includeOpenGraphMeta"><?php _e(' Include OpenGraph meta information'); ?></label>
 				<em><?php _e(" (This will add the following meta information to the page &lt;head&gt; to assist with Like button clicks: post/page title, site name, current URL and content type)"); ?></em></p>
+				
+			<p><input type="checkbox" id="fbComments_includeHiddenSEOComments" name="fbComments[includeHiddenSEOComments]" value="1" <?php checked($fbc_options['includeHiddenSEOComments'], 1 ); ?> size="20">
+				<label for="fbComments_includeHiddenSEOComments"><?php _e(' Include Hidden SEO Comments'); ?></label>
+				<em><?php _e(" (This will add a SEO-friendly hidden box with the comments as recommended <a href=\"https://developers.facebook.com/docs/reference/plugins/comments/\" target=\"_blank\">here</a>.  It's highly recommended to only activate this setting when using some WordPress caching plugin to avoid excessive API calls.)"); ?></em></p>				
 		</div>
 	</div>
 

--- a/facebook-comments-admin.php
+++ b/facebook-comments-admin.php
@@ -223,6 +223,13 @@ if (version_compare(phpversion(), FBCOMMENTS_REQUIRED_PHP_VER) == -1) {
 
 			<p><input type="checkbox" id="fbComments_noBox" name="fbComments[noBox]" value="1" <?php checked($fbc_options['noBox'], 1 ); ?> size="20">
 				<label for="fbComments_noBox"><?php _e(' Remove grey box surrounding Facebook comments'); ?></label></p>
+
+			<p><input type="checkbox" id="fbComments_hideClosed" name="fbComments[hideClosed]" value="1" <?php checked($fbc_options['hideClosed'], 1 ); ?> size="20">
+				<label for="fbComments_hideClosed"><?php _e('<em>*just added*</em> Hide &quot;Comments Closed&quot; message.'); ?>
+				</label>
+			</p>
+
+
 		</div>
 	</div>
 

--- a/facebook-comments-display.php
+++ b/facebook-comments-display.php
@@ -288,8 +288,14 @@
 					}
 			
 					// output comment and user
-					print '<li><a href="'.$user->link.'"><img src="https://graph.facebook.com/'.$user->id.'/picture" alt="'.$user->first_name . ' ' . $user->last_name .'" /></a><br />'."\n";
-					print '<strong><a href="'.$user->link.'">'.$user->first_name . ' ' . $user->last_name .'</a></strong>: '."\n";
+					print '<li>';
+					if (empty($user->link)) {
+						print '<img src="https://graph.facebook.com/'.$user->id.'/picture" alt="'.$user->first_name . ' ' . $user->last_name .'" /><br />'."\n";
+						print '<strong>'.$user->first_name . ' ' . $user->last_name .'</strong>: '."\n";
+					} else { 
+						print '<a href="'.$user->link.'"><img src="https://graph.facebook.com/'.$user->id.'/picture" alt="'.$user->first_name . ' ' . $user->last_name .'" /></a><br />'."\n";
+						print '<strong><a href="'.$user->link.'">'.$user->first_name . ' ' . $user->last_name .'</a></strong>: '."\n";
+					}
 					print '<p>'.make_clickable($comment->text).'</p>';
 					print '<span class="date">'.date("M j \a\\t g:ia", $comment->time).'</span>';
 			
@@ -311,8 +317,14 @@
 								$user = $users[$reply->fromid];
 							}
 							// output the replies
-							print '<li><a href="'.$user->link.'"><img src="https://graph.facebook.com/'.$user->id.'/picture" alt="'.$user->first_name . ' ' . $user->last_name .'" /></a><br />'."\n";
-							print '<strong><a href="'.$user->link.'">'.$user->first_name . ' ' . $user->last_name .'</a></strong>:'."\n";
+							print '<li>';
+							if (empty($user->link)) {
+								print '<img src="https://graph.facebook.com/'.$user->id.'/picture" alt="'.$user->first_name . ' ' . $user->last_name .'" /><br />'."\n";
+								print '<strong>'.$user->first_name . ' ' . $user->last_name .'</strong>: '."\n";
+							} else { 
+								print '<a href="'.$user->link.'"><img src="https://graph.facebook.com/'.$user->id.'/picture" alt="'.$user->first_name . ' ' . $user->last_name .'" /></a><br />'."\n";
+								print '<strong><a href="'.$user->link.'">'.$user->first_name . ' ' . $user->last_name .'</a></strong>: '."\n";
+							}
 							print '<p>'.make_clickable($reply->text).'</p>';
 							print '<span class="date">'.date("M j \a\\t g:ia", $reply->time).'</span>';
 							print '</li>'."\n\n";

--- a/facebook-comments-display.php
+++ b/facebook-comments-display.php
@@ -171,7 +171,8 @@
 		echo "
 	};
 
-	FB.Event.subscribe('comments.add', addedComment);
+	// Facebook has changed the event name
+	FB.Event.subscribe('comment.create', addedComment);
 </script>\n";
 	}
 

--- a/facebook-comments-display.php
+++ b/facebook-comments-display.php
@@ -9,6 +9,7 @@
 
 		// Return out of function if commenting is closed for this post
 	    if (!comments_open()) {
+                if ($fbc_options['hideClosed'] != 1)
 			echo "<h2>Comments Closed</h2>";
 	    	return $comments;
 	    }


### PR DESCRIPTION
I made two quick changes to facebook-comments-display.php and facebook-comments-admin.php that give a user the option to hide the "Comments Closed" message when commenting is disabled on a post or a page.  Change has been tested on my end and works like a charm.  

In addition I changed the name of the FB.Event.Subscribe event from    comments.add     to comment.create, as the other event was not working.  See:   https://developers.facebook.com/docs/reference/javascript/FB.Event.subscribe/   for more information.
# UPDATE:    August 16, 2011

Added functionality for hidden SEO friendly comment box, behind Facebook comments as specified in the "How can I get an SEO boost from the comments left on my site?" section of https://developers.facebook.com/docs/reference/plugins/comments/
