### PR TITLE
Fix for comment count not updating

### DIFF
--- a/facebook-comments-ajax.php
+++ b/facebook-comments-ajax.php
@@ -14,18 +14,24 @@
 	}
 
 	global $fbc_options;
+	$count = get_option("fbComments_commentCount_{$_POST['xid']}");
 
 	// Check if we want to update the comment count or send a notification email
 	switch ($_POST['fn']) {
 		// Update Facebook comment count
     	case "addComment":
+            $newCount = $count+1;
+            // no break on purpose
+
+        case "removeComment":
+            $newCount = $count-1;
+
     		fbComments_log('In ' . basename(__FILE__) . " with fn={$_POST['fn']}, xid={$_POST['xid']}");
-    		$count = get_option("fbComments_commentCount_{$_POST['xid']}");
-    	    if (update_option("fbComments_commentCount_{$_POST['xid']}", $count+1)) {
+    	    if (update_option("fbComments_commentCount_{$_POST['xid']}", $newCount)) {
     	    	fbComments_log(sprintf('    Updated Facebook comment count from %d to %d', $count, $count+1));
     	    	echo 'true';
     	    } else {
-    	    	fbComments_log(sprintf('    FAILED to update Facebook comment count from %d to %d', $count, $count+1));
+    	    	fbComments_log(sprintf('    FAILED to update Facebook comment count from %d to %d', $count, $newCount));
     	    	echo 'false';
     	    }
 

--- a/facebook-comments-ajax.php
+++ b/facebook-comments-ajax.php
@@ -20,11 +20,13 @@
 	switch ($_POST['fn']) {
 		// Update Facebook comment count
     	case "addComment":
-            $newCount = $count+1;
             // no break on purpose
-
         case "removeComment":
-            $newCount = $count-1;
+            if ($_POST['fn']=='addComment') {
+                $newCount = $count+1;
+            } else {
+                $newCount = $count-1;
+            }
 
     		fbComments_log('In ' . basename(__FILE__) . " with fn={$_POST['fn']}, xid={$_POST['xid']}");
     	    if (update_option("fbComments_commentCount_{$_POST['xid']}", $newCount)) {

--- a/facebook-comments-combinecomments.php
+++ b/facebook-comments-combinecomments.php
@@ -22,8 +22,8 @@ function fbComments_getProperCommentCount($fbCommentCount=0, $wpCommentCount=0) 
 		return $fbCommentCount;
 	// If commenting is closed on this post or we shouldn't be displaying Facebook comments due to settings, just return the WordPress comments count
 	} elseif (!comments_open() ||
-			  ($fbc_options['displayPagesOrPosts'] == 'pages') && (!is_page()) ||
-			  ($fbc_options['displayPagesOrPosts'] == 'posts') && (!is_single())) {
+			  ($fbc_options['displayPagesOrPosts'] == 'pages') && (is_single()) ||
+			  ($fbc_options['displayPagesOrPosts'] == 'posts') && (is_page())) {
 	  return $wpCommentCount;
 	} else {
 		fbComments_log(sprintf('    Returning a combined comment count of %d', $fbCommentCount+$wpCommentCount));

--- a/facebook-comments-display.php
+++ b/facebook-comments-display.php
@@ -146,12 +146,12 @@
 <script type='text/javascript'>
 	var addedComment = function(response) {
 		//console.log('fbComments: Caught added comment');
-		//console.log('fbComments:     Making AJAX call to update Facebook comment count');
+		//console.log('fbComments:     Making AJAX call to update (increase) Facebook comment count');
 		jQuery.post('" . FBCOMMENTS_PATH . "facebook-comments-ajax.php', { fn: 'addComment', xid: '$xid' }, function(resp) {
 			if (resp === 'true') {
-				//console.log('fbComments:     Updated and cached Facebook comment count for post with xid=$xid');
+				//console.log('fbComments:     Updated (increased) and cached Facebook comment count for post with xid=$xid');
 			} else {
-				//console.log('fbComments:     FAILED to update Facebook comment count for post with xid=$xid');
+				//console.log('fbComments:     FAILED to update (increase) Facebook comment count for post with xid=$xid');
 			}
 		});\n";
 
@@ -170,7 +170,20 @@
 		echo "
 	};
 
+    var removedComment = function(response) {
+		//console.log('fbComments: Caught removed comment');
+		//console.log('fbComments:     Making AJAX call to update (decrease) Facebook comment count');
+		jQuery.post('" . FBCOMMENTS_PATH . "facebook-comments-ajax.php', { fn: 'removeComment', xid: '$xid' }, function(resp) {
+			if (resp === 'true') {
+				//console.log('fbComments:     Updated (decreased) and cached Facebook comment count for post with xid=$xid');
+			} else {
+				//console.log('fbComments:     FAILED to update (decrease) Facebook comment count for post with xid=$xid');
+			}
+		});
+    }
+
     FB.Event.subscribe('comment.create', addedComment);
+    FB.Event.subscribe('comment.remove', removedComment);
 </script>\n";
 	}
 

--- a/facebook-comments-display.php
+++ b/facebook-comments-display.php
@@ -147,7 +147,7 @@
 	var addedComment = function(response) {
 		//console.log('fbComments: Caught added comment');
 		//console.log('fbComments:     Making AJAX call to update Facebook comment count');
-		$.post('" . FBCOMMENTS_PATH . "facebook-comments-ajax.php', { fn: 'addComment', xid: '$xid' }, function(resp) {
+		jQuery.post('" . FBCOMMENTS_PATH . "facebook-comments-ajax.php', { fn: 'addComment', xid: '$xid' }, function(resp) {
 			if (resp === 'true') {
 				//console.log('fbComments:     Updated and cached Facebook comment count for post with xid=$xid');
 			} else {
@@ -158,7 +158,7 @@
 		if ($fbc_options['notify']) {
 			echo "
 		//console.log('fbComments:     Making AJAX call to send email notification');
-		$.post('" . FBCOMMENTS_PATH . "facebook-comments-ajax.php', { fn: 'sendNotification', xid: '$xid', postTitle: '$postTitle', postUrl: '$postUrl' }, function(resp) {
+		jQuery.post('" . FBCOMMENTS_PATH . "facebook-comments-ajax.php', { fn: 'sendNotification', xid: '$xid', postTitle: '$postTitle', postUrl: '$postUrl' }, function(resp) {
 			if (resp === 'true') {
 				//console.log('fbComments:     Sent email notification');
 			} else {

--- a/facebook-comments-display.php
+++ b/facebook-comments-display.php
@@ -170,7 +170,7 @@
 		echo "
 	};
 
-	FB.Event.subscribe('comments.add', addedComment);
+    FB.Event.subscribe('comment.create', addedComment);
 </script>\n";
 	}
 


### PR DESCRIPTION
Due to changes in the Facebook API, `FB.Event.subscribe('comments.add', addedComment);` wasn't working. I updated it to the new `comment.create`.

I also added the functionality to update the comment count not just when a comment is added, but also when a comment gets deleted.

And a third fix is avoiding JS conflicts with jQuery.
