### PR TITLE
Fixing comments count

### DIFF
--- a/facebook-comments-display.php
+++ b/facebook-comments-display.php
@@ -296,5 +296,5 @@ echo "</div>\n";
 	function fbc_facebook_comment_count($ccount='') {
 		global $fbc_options, $wp_query;
 	    $postUrl = get_permalink($wp_query->post->ID);
-        echo "<span data-href='$postUrl'></span> <span class='fb_comments_text'>comments</span>";
+        echo "<span class='fb_comments_link_text'><span data-href='$postUrl'></span> <span class='fb_comments_text'>comments</span></span>";
 	}

--- a/facebook-comments-display.php
+++ b/facebook-comments-display.php
@@ -296,5 +296,5 @@ echo "</div>\n";
 	function fbc_facebook_comment_count($ccount='') {
 		global $fbc_options, $wp_query;
 	    $postUrl = get_permalink($wp_query->post->ID);
-        echo '<fb:comments-count href='$postUrl'></fb:comments-count> comments';
+        echo "<span data-href='$postUrl'></span> <span class='fb_comments_text'>comments</span>";
 	}

--- a/facebook-comments-display.php
+++ b/facebook-comments-display.php
@@ -296,5 +296,5 @@ echo "</div>\n";
 	function fbc_facebook_comment_count($ccount='') {
 		global $fbc_options, $wp_query;
 	    $postUrl = get_permalink($wp_query->post->ID);
-        echo "<span class='fb_comments_link_text'><span data-href='$postUrl'></span> <span class='fb_comments_text'>comments</span></span>";
+        echo "<span class='fb_comments_link_text'>View <span data-href='$postUrl'></span> <span class='fb_comments_text'> comments</span></span>";
 	}

--- a/facebook-comments-display.php
+++ b/facebook-comments-display.php
@@ -171,8 +171,16 @@
 		});
     }
 
-    FB.Event.subscribe('comment.create', addedComment);
-    FB.Event.subscribe('comment.remove', removedComment);
+    // Wait for FB to load and then subscribe
+    var subscribe = function() {
+        if (typeof(FB) != 'undefined' && FB != null) {
+            FB.Event.subscribe('comment.create', addedComment);
+            FB.Event.subscribe('comment.remove', removedComment);
+        } else {
+            setTimeout(subscribe, 1000);
+        }
+    };
+    setTimeout(subscribe, 200);
 </script>\n";
 	}
 

--- a/facebook-comments-display.php
+++ b/facebook-comments-display.php
@@ -36,7 +36,7 @@
 			fbComments_storeAccessToken();
 
 			echo "\n<!-- Facebook Comments for WordPress v" . FBCOMMENTS_VER . " by " . FBCOMMENTS_AUTHOR . " (" . FBCOMMENTS_WEBPAGE . ") -->\n
-<a name='facebook-comments'></a>\n";
+<a name='comments'></a><a name='facebook-comments'></a>\n";
 
 	    	if ($fbc_options['includeFbJs']) {
 	    		fbComments_includeFbJs();
@@ -296,10 +296,5 @@ echo "</div>\n";
 	function fbc_facebook_comment_count($ccount='') {
 		global $fbc_options, $wp_query;
 	    $postUrl = get_permalink($wp_query->post->ID);
-		
-		echo "</a><iframe src='http://www.facebook.com/plugins/comments.php?href=$postUrl&permalink=1'"
-				." scrolling='no' frameborder='0' style='{$fbc_options['v2ccstyle']}'"
-				." allowTransparency='true'>
-			</iframe><a>";
-		// echo "\tcmt</a><fb:comments-count href='$postUrl'></fb:comments-count> comments<a>";
+        echo '<fb:comments-count href='$postUrl'></fb:comments-count> comments';
 	}

--- a/facebook-comments.php
+++ b/facebook-comments.php
@@ -33,6 +33,7 @@
 	require_once 'facebook-comments-display.php';
 	require_once 'scripts/facebook.php'; # Facebook API wrapper
 	wp_enqueue_script('jquery');
+    wp_enqueue_script('comment_counts', plugins_url('webpage/_scripts/comment_counts.js', __FILE__), array('jquery'));
 
 	/**********************************
 	 Globals

--- a/webpage/_scripts/comment_counts.js
+++ b/webpage/_scripts/comment_counts.js
@@ -1,0 +1,31 @@
+(function($) {
+  $(document).ready(function() {
+    var url_elements = $("span[data-href]");
+    var urls = url_elements.map(function(index, elem) { return $(elem).data('href'); }).toArray();
+    var app_key = $('meta[property=fb\\:app_id]').attr('content');
+
+    var queries = {index_link_status_url: 'select url,commentsbox_count from link_stat where url in ("' + urls.join('","') + '")'};
+    data = {
+      api_key: app_key,
+      format: "json-strings",
+      method: "fql.multiquery",
+      pretty: "0",
+      queries: JSON.stringify(queries),
+      sdk: "joey"
+    };
+    $.getJSON("//api-read.facebook.com/restserver.php", data, function(data) {
+      var results = data[0]['fql_result_set'];
+      var fb_tags = {};
+      url_elements.each(function(index, elem) {
+        var jElem = $(elem);
+        fb_tags[jElem.data('href')] = jElem;
+      });
+      $(results).each(function(index, elem) {
+        fb_tags[elem.url].text(elem.commentsbox_count);
+        if (parseInt(elem.commentsbox_count) == 1) {
+          fb_tags[elem.url].parent().find("span.fb_comments_text").text("comment");
+        }
+      });
+    });
+  });
+}(jQuery));


### PR DESCRIPTION
Hey there,

This plugin seems deserted, but in case it isn't there are a couple of fixes I've done.
The problem was that I wanted the number of comments to be shown, the link to the comments to work, to have it work in SSL pages (no mixed content warnings) and to have it show "1 comment" or "X comment/s/"

Let me know if there's anything preventing this from being merged

Cheers!
